### PR TITLE
Support OpenSSL (as well as Sodium) extensions for encryption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 language: php
 
 php:
+  - 7.0
+  - 7.1
   - 7.2
   - 7.3
   - 7.4
@@ -14,7 +16,7 @@ matrix:
 
 install:
   - |
-    if php -r 'exit((int)extension_loaded("sodium"));'; then
+    if php -r 'exit((int)(extension_loaded("sodium") || extension_loaded("openssl")));'; then
       git clone -b stable https://github.com/jedisct1/libsodium.git
       cd libsodium && sudo ./configure && sudo make check && sudo make install && cd ..
       pecl install libsodium

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     "xp-lang/php-compact-methods": "^1.0",
     "xp-lang/xp-enums": "^1.0",
     "xp-lang/xp-records": "^1.0",
-    "php" : ">=7.2.0",
-    "ext-sodium" : "*"
+    "php" : ">=7.0.0"
   },
 
   "require-dev": {

--- a/src/main/php/de/thekid/cas/Encryption.php
+++ b/src/main/php/de/thekid/cas/Encryption.php
@@ -22,8 +22,8 @@ class Encryption {
     } else if (extension_loaded('openssl')) {
       self::$klength= openssl_cipher_iv_length('DES');
       self::$nlength= openssl_cipher_iv_length('DES');
-      self::$encrypt= fn($value, $nonce, $key) => openssl_encrypt($value, 'DES', $key->reveal(),  0, $nonce);
-      self::$decrypt= fn($cipher, $nonce, $key) => openssl_decrypt($cipher, 'DES', $key->reveal(),  0, $nonce);
+      self::$encrypt= fn($value, $nonce, $key) => openssl_encrypt($value, 'DES', $key->reveal(), 0, $nonce);
+      self::$decrypt= fn($cipher, $nonce, $key) => openssl_decrypt($cipher, 'DES', $key->reveal(), 0, $nonce);
     } else {
       throw new IllegalAccessException('Expected either sodium or openssl extension to be loaded');
     }

--- a/src/main/php/de/thekid/cas/Encryption.php
+++ b/src/main/php/de/thekid/cas/Encryption.php
@@ -1,6 +1,6 @@
 <?php namespace de\thekid\cas;
 
-use lang\FormatException;
+use lang\{FormatException, IllegalAccessException};
 use util\{Random, Secret};
 
 /**
@@ -10,12 +10,35 @@ use util\{Random, Secret};
  * @see   https://deliciousbrains.com/php-encryption-methods/
  */
 class Encryption {
-  private $key, $random;
+  private $key;
+  private static $random, $nlength, $klength, $encrypt, $decrypt;
+
+  static function __static() {
+    if (extension_loaded('sodium')) {
+      self::$nlength= SODIUM_CRYPTO_SECRETBOX_NONCEBYTES;
+      self::$klength= SODIUM_CRYPTO_SECRETBOX_KEYBYTES;
+      self::$encrypt= fn($value, $nonce, $key) => sodium_crypto_secretbox($value, $nonce, $key->reveal());
+      self::$decrypt= fn($cipher, $nonce, $key) => sodium_crypto_secretbox_open($cipher, $nonce, $key->reveal());
+    } else if (extension_loaded('openssl')) {
+      self::$klength= openssl_cipher_iv_length('DES');
+      self::$nlength= openssl_cipher_iv_length('DES');
+      self::$encrypt= fn($value, $nonce, $key) => openssl_encrypt($value, 'DES', $key->reveal(),  0, $nonce);
+      self::$decrypt= fn($cipher, $nonce, $key) => openssl_decrypt($cipher, 'DES', $key->reveal(),  0, $nonce);
+    } else {
+      throw new IllegalAccessException('Expected either sodium or openssl extension to be loaded');
+    }
+
+    self::$random= new Random();
+  }
 
   /** Creates a new Encryption instance with a given secret key */
   public function __construct(string|Secret $key) {
     $this->key= $key instanceof Secret ? $key : new Secret($key);
-    $this->random= new Random();
+  }
+
+  /** Creates a new random key */
+  public static function randomKey(): Secret {
+    return new Secret((string)self::$random->bytes(self::$klength));
   }
 
   /**
@@ -25,8 +48,8 @@ class Encryption {
    * @return string Base64 encoded
    */
   public function encrypt($value) {
-    $nonce= (string)$this->random->bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
-    $cipher= sodium_crypto_secretbox($value, $nonce, $this->key->reveal());
+    $nonce= (string)self::$random->bytes(self::$nlength);
+    $cipher= (self::$encrypt)($value, $nonce, $this->key);
     return base64_encode($nonce.$cipher);
   }
 
@@ -39,18 +62,21 @@ class Encryption {
    */
   public function decrypt($encoded) {
     $bytes= base64_decode($encoded);
-    $nonce= substr($bytes, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
-    $cipher= substr($bytes, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+    $nonce= substr($bytes, 0, self::$nlength);
+    $cipher= substr($bytes, self::$nlength);
 
     try {
-      $r= sodium_crypto_secretbox_open($cipher, $nonce, $this->key->reveal());
-    } catch (\SodiumException $e) {
+      $r= (self::$decrypt)($cipher, $nonce, $this->key);
+    } catch ($e) {
       throw new FormatException('Internal decryption error', $e);
     }
 
     if (false === $r) {
-      throw new FormatException('Cannot decrypt given value');
+      $e= new FormatException('Cannot decrypt given value');
+      \xp::gc(__FILE__);
+      throw $e;
     }
+
     return $r;
   }
 }

--- a/src/test/php/de/thekid/cas/unittest/EncryptionTest.php
+++ b/src/test/php/de/thekid/cas/unittest/EncryptionTest.php
@@ -10,7 +10,7 @@ class EncryptionTest {
 
   #[Before]
   public function randomKey() {
-    $this->key= new Random()->bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
+    $this->key= Encryption::randomKey();
   }
 
   #[Test]
@@ -19,8 +19,8 @@ class EncryptionTest {
   }
 
   #[Test]
-  public function can_create_with_secret() {
-    new Encryption(new Secret($this->key));
+  public function can_create_with_string() {
+    new Encryption($this->key->reveal());
   }
 
   #[Test, Values([


### PR DESCRIPTION
Implements #4. This way, we add support for PHP 7.0 and PHP 7.1