### PR TITLE
Refactor persistence

### DIFF
--- a/src/main/etc/local/inject.ini
+++ b/src/main/etc/local/inject.ini
@@ -1,3 +1,4 @@
-string[conn]=mysql://cas:${secret.cas_db_pass}@localhost/IDENTITIES
+de.thekid.cas.Persistence=de.thekid.cas.InDatabase("mysql://cas:${secret.cas_db_pass}@localhost/IDENTITIES")
+
 string[services]=https?://thekid.de|http://localhost:3000
 string[secret]=${secret.crypto_key}

--- a/src/main/php/de/thekid/cas/Implementations.php
+++ b/src/main/php/de/thekid/cas/Implementations.php
@@ -1,9 +1,10 @@
 <?php namespace de\thekid\cas;
 
 use de\thekid\cas\services\{Services, AllowMatching};
-use de\thekid\cas\tickets\{Tickets, TicketDatabase};
-use de\thekid\cas\users\{Users, UserDatabase};
+use de\thekid\cas\tickets\Tickets;
+use de\thekid\cas\users\Users;
 use inject\Bindings;
+use lang\IllegalStateException;
 
 /** Default implementations for services, users and tickets */
 class Implementations extends Bindings {
@@ -15,7 +16,9 @@ class Implementations extends Bindings {
     $inject->bind(Signed::class, new Signed($secret));
     $inject->bind(Encryption::class, new Encryption($secret));
     $inject->bind(Services::class, new AllowMatching($inject->get('string', 'services')));
-    $inject->bind(Users::class, $inject->get(UserDatabase::class));
-    $inject->bind(Tickets::class, $inject->get(TicketDatabase::class));
+
+    $persistence= $inject->get(Persistence::class) ?? throw new IllegalStateException('No persistence configured');
+    $inject->bind(Users::class, $persistence->users());
+    $inject->bind(Tickets::class, $persistence->tickets());
   }
 }

--- a/src/main/php/de/thekid/cas/InDatabase.php
+++ b/src/main/php/de/thekid/cas/InDatabase.php
@@ -1,0 +1,31 @@
+<?php namespace de\thekid\cas;
+
+use de\thekid\cas\rdbms\{UserDatabase, TicketDatabase};
+use de\thekid\cas\tickets\Tickets;
+use de\thekid\cas\users\Users;
+use rdbms\{DBConnection, DriverManager};
+
+/**
+ * Persists users and tickets in a relational database, to which the
+ * connection is passed in the constructor.
+ *
+ * @see de.thekid.cas.Implementations
+ */
+class InDatabase implements Persistence {
+  private $conn, $users, $tickets;
+
+  /** Creates a new database-driven datasource */
+  public function __construct(string|DBConnection $conn) {
+    $this->conn= $conn instanceof DBConnection ? $conn : DriverManager::getConnection($conn);
+  }
+
+  /** Returns users persistence */
+  public function users(): Users {
+    return $this->users??= new UserDatabase($this->conn);
+  }
+
+  /** Returns tickets persistence */
+  public function tickets(): Tickets {
+    return $this->tickets??= new TicketDatabase($this->conn);
+  }
+}

--- a/src/main/php/de/thekid/cas/Persistence.php
+++ b/src/main/php/de/thekid/cas/Persistence.php
@@ -1,0 +1,14 @@
+<?php namespace de\thekid\cas;
+
+use de\thekid\cas\tickets\Tickets;
+use de\thekid\cas\users\Users;
+
+interface Persistence {
+
+  /** Returns users persistence */
+  public function users(): Users;
+
+  /** Returns tickets persistence */
+  public function tickets(): Tickets;
+
+}

--- a/src/main/php/de/thekid/cas/Signed.php
+++ b/src/main/php/de/thekid/cas/Signed.php
@@ -17,12 +17,12 @@ class Signed {
 
   /** Signs an ID */
   public function id(int|string $id, string $prefix= ''): string {
-    return $prefix.$id.'-'.md5($id.$this->secret->reveal());
+    return $prefix.md5($id.$this->secret->reveal()).'-'.$id;
   }
 
   /** Verifies a signed string, returning the underlying ID */
   public function verify(?string $signed, string $prefix= ''): ?string {
-    if (null !== $signed && 2 === sscanf($signed, $prefix.'%[^-]-%s', $id, $hash)) {
+    if (null !== $signed && 2 === sscanf($signed, $prefix.'%[0-9a-f]-%s', $hash, $id)) {
       if ($hash === md5($id.$this->secret->reveal())) return $id;
     }
     return null;

--- a/src/main/php/de/thekid/cas/Signed.php
+++ b/src/main/php/de/thekid/cas/Signed.php
@@ -15,14 +15,14 @@ class Signed {
     $this->secret= $secret instanceof Secret ? $secret : new Secret($secret);
   }
 
-  /** Signs an integer ID */
-  public function id(int $id, string $prefix= ''): string {
+  /** Signs an ID */
+  public function id(int|string $id, string $prefix= ''): string {
     return $prefix.$id.'-'.md5($id.$this->secret->reveal());
   }
 
   /** Verifies a signed string, returning the underlying ID */
-  public function verify(?string $signed, string $prefix= ''): ?int {
-    if (null !== $signed && 2 === sscanf($signed, $prefix.'%d-%s', $id, $hash)) {
+  public function verify(?string $signed, string $prefix= ''): ?string {
+    if (null !== $signed && 2 === sscanf($signed, $prefix.'%[^-]-%s', $id, $hash)) {
       if ($hash === md5($id.$this->secret->reveal())) return $id;
     }
     return null;

--- a/src/main/php/de/thekid/cas/flow/EnterCredentials.php
+++ b/src/main/php/de/thekid/cas/flow/EnterCredentials.php
@@ -38,6 +38,7 @@ class EnterCredentials implements Step {
 
       $error= ['failed' => $result];
     } catch (Throwable $t) {
+      $t->printStackTrace();
       $error= ['exception' => $t];
     }
 

--- a/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
@@ -13,16 +13,13 @@ use util\{Date, Dates};
  * value     tinytext
  * created   datetime
  */
-class TicketDatabase implements Tickets {
+class TicketDatabase extends Tickets {
   private $conn;
 
   /** Creates a new database-driven tickets data source */
   public function __construct(string|DBConnection $conn, private int $timeout= 10) {
     $this->conn= $conn instanceof DBConnection ? $conn : DriverManager::getConnection($conn);
   }
-
-  /** @return string */
-  public fn prefix() => 'ST-';
 
   /**
    * Creates a new ticket

--- a/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
@@ -28,7 +28,7 @@ class TicketDatabase implements Tickets {
    * Creates a new ticket
    *
    * @param  var $value
-   * @return int
+   * @return int|string
    */
   public function create($value) {
     $this->conn->insert('into ticket (value, created) values (%s, %s)', json_encode($value), Date::now());
@@ -38,7 +38,7 @@ class TicketDatabase implements Tickets {
   /**
    * Looks up and verifies a ticket by a given ID.
    *
-   * @param   int $id
+   * @param   int|string $id
    * @return  var or NULL to indicate the ticket could not be verified.
    */
   public function validate($id) {

--- a/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
@@ -1,5 +1,6 @@
-<?php namespace de\thekid\cas\tickets;
+<?php namespace de\thekid\cas\rdbms;
 
+use de\thekid\cas\tickets\Tickets;
 use rdbms\{DBConnection, DriverManager};
 use util\{Date, DateUtil};
 

--- a/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
@@ -2,7 +2,7 @@
 
 use de\thekid\cas\tickets\Tickets;
 use rdbms\{DBConnection, DriverManager};
-use util\{Date, DateUtil};
+use util\{Date, Dates};
 
 /**
  * Minimalistic ticket database implementation
@@ -48,7 +48,7 @@ class TicketDatabase implements Tickets {
     if (null === $ticket) return null;
 
     // Clean up tickets older than maximum timeout
-    $timeout= DateUtil::addSeconds(Date::now(), -$this->timeout);
+    $timeout= Dates::add(Date::now(), -$this->timeout);
     $this->conn->delete('from ticket where created < %s', $timeout);
 
     // Verify timeout has not been reached

--- a/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/TicketDatabase.php
@@ -14,12 +14,9 @@ use util\{Date, Dates};
  * created   datetime
  */
 class TicketDatabase extends Tickets {
-  private $conn;
 
   /** Creates a new database-driven tickets data source */
-  public function __construct(string|DBConnection $conn, private int $timeout= 10) {
-    $this->conn= $conn instanceof DBConnection ? $conn : DriverManager::getConnection($conn);
-  }
+  public function __construct(private DBConnection $conn, private int $timeout= 10) { }
 
   /**
    * Creates a new ticket

--- a/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
@@ -21,12 +21,9 @@ use util\Secret;
  * secret    varchar
  */
 class UserDatabase extends Users {
-  private $conn;
 
   /** Creates a new database-driven datasource */
-  public function __construct(string|DBConnection $conn) {
-    $this->conn= $conn instanceof DBConnection ? $conn : DriverManager::getConnection($conn);
-  }
+  public function __construct(private DBConnection $conn) { }
 
   /** Fetches tokens */
   private function tokens($id): array<string, string> {

--- a/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
@@ -37,9 +37,9 @@ class UserDatabase extends Users {
   /** Returns all users */
   public function all(?string $filter= null): iterable {
     if (null === $filter) {
-      $it= $this->conn->open('select * from user left join token on user.user_id = token.user_id');
+      $q= $this->conn->open('select * from user left join token on user.user_id = token.user_id');
     } else {
-      $it= $this->conn->open(
+      $q= $this->conn->open(
         'select * from user left join token on user.user_id = token.user_id where username like %s',
         strtr($filter, '*', '%')
       );
@@ -47,7 +47,7 @@ class UserDatabase extends Users {
 
     // Separate cross productmath into user and tokens
     $user= null;
-    foreach ($it as $record) {
+    while ($record= $q->next()) {
       if ($record['username'] !== $user['username']) {
         $user && yield new User($user['username'], $user['tokens']);
         $user= $record + ['tokens' => []];

--- a/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
@@ -2,7 +2,6 @@
 
 use de\thekid\cas\users\{User, Users};
 use rdbms\{DBConnection, DriverManager};
-use text\hash\{Hashing, HashCode};
 use util\Secret;
 
 /**
@@ -22,12 +21,11 @@ use util\Secret;
  * secret    varchar
  */
 class UserDatabase extends Users {
-  private $conn, $hash;
+  private $conn;
 
   /** Creates a new database-driven datasource */
   public function __construct(string|DBConnection $conn) {
     $this->conn= $conn instanceof DBConnection ? $conn : DriverManager::getConnection($conn);
-    $this->hash= Hashing::sha256();
   }
 
   /** Fetches tokens */

--- a/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
@@ -21,7 +21,7 @@ use util\Secret;
  * name      varchar
  * secret    varchar
  */
-class UserDatabase implements Users {
+class UserDatabase extends Users {
   private $conn, $hash;
 
   /** Creates a new database-driven datasource */

--- a/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
@@ -1,5 +1,6 @@
-<?php namespace de\thekid\cas\users;
+<?php namespace de\thekid\cas\rdbms;
 
+use de\thekid\cas\users\{User, Users, NoSuchUser, PasswordMismatch, Authentication, Authenticated};
 use rdbms\{DBConnection, DriverManager};
 use text\hash\{Hashing, HashCode};
 use util\Secret;

--- a/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
+++ b/src/main/php/de/thekid/cas/rdbms/UserDatabase.php
@@ -49,7 +49,7 @@ class UserDatabase extends Users {
     $user= null;
     while ($record= $q->next()) {
       if ($record['username'] !== $user['username']) {
-        $user && yield new User($user['username'], $user['tokens']);
+        $user && yield new User($user['username'], $user['hash'], $user['tokens']);
         $user= $record + ['tokens' => []];
       }
       $record['token_id'] && $user['tokens'][$record['name']]= $record['secret'];

--- a/src/main/php/de/thekid/cas/tickets/Tickets.php
+++ b/src/main/php/de/thekid/cas/tickets/Tickets.php
@@ -9,14 +9,14 @@ interface Tickets {
    * Creates a new ticket
    *
    * @param  var $value
-   * @return int
+   * @return int|string
    */
   public function create($user);
 
   /**
    * Looks up and verifies a ticket by a given ID.
    *
-   * @param   int $id
+   * @param   int|string $id
    * @return  var or NULL to indicate the ticket could not be verified.
    */
   public function validate($id);

--- a/src/main/php/de/thekid/cas/tickets/Tickets.php
+++ b/src/main/php/de/thekid/cas/tickets/Tickets.php
@@ -1,9 +1,9 @@
 <?php namespace de\thekid\cas\tickets;
 
-interface Tickets {
+abstract class Tickets {
 
   /** @return string */
-  public function prefix();
+  public fn prefix() => 'ST-';
 
   /**
    * Creates a new ticket
@@ -11,7 +11,7 @@ interface Tickets {
    * @param  var $value
    * @return int|string
    */
-  public function create($user);
+  public abstract function create($user);
 
   /**
    * Looks up and verifies a ticket by a given ID.
@@ -19,5 +19,5 @@ interface Tickets {
    * @param   int|string $id
    * @return  var or NULL to indicate the ticket could not be verified.
    */
-  public function validate($id);
+  public abstract function validate($id);
 }

--- a/src/main/php/de/thekid/cas/users/User.php
+++ b/src/main/php/de/thekid/cas/users/User.php
@@ -1,7 +1,15 @@
 <?php namespace de\thekid\cas\users;
 
-record User(string $username, array<string> $tokens) {
+record User(string $username, string $hash, array<string, string> $tokens) {
 
   /** Returns whether any TOTP tokens exist */
   public fn mfa() => !empty($this->tokens);
+
+  /** Custom string representation */
+  public fn toString() => sprintf(
+    '%s(username: %s, tokens: [%s])',
+    nameof($this),
+    $this->username,
+    implode(', ', array_keys($this->tokens))
+  );
 }

--- a/src/main/php/de/thekid/cas/users/Users.php
+++ b/src/main/php/de/thekid/cas/users/Users.php
@@ -2,24 +2,24 @@
 
 use util\Secret;
 
-interface Users {
+abstract class Users {
 
   /** Authenticates a user, returning success or failure in a result object */
-  public function authenticate(string $username, Secret $password): Authentication;
+  public abstract function authenticate(string $username, Secret $password): Authentication;
 
   /** Returns all users */
-  public function all(?string $filter= null): iterable;
+  public abstract function all(?string $filter= null): iterable;
 
   /** Returns a user by a given username */
-  public function named(string $username): ?User;
+  public abstract function named(string $username): ?User;
 
   /** Creates a new user with a given username and password. */
-  public function create(string $username, string|Secret $password): User;
+  public abstract function create(string $username, string|Secret $password): User;
 
   /** Removes an existing user */
-  public function remove(string|User $user): void;
+  public abstract function remove(string|User $user): void;
 
   /** Changes a user's password. */
-  public function password(string|User $user, string|Secret $password): void;
+  public abstract function password(string|User $user, string|Secret $password): void;
 
 }

--- a/src/main/php/de/thekid/cas/users/Users.php
+++ b/src/main/php/de/thekid/cas/users/Users.php
@@ -23,7 +23,7 @@ abstract class Users {
 
   /** Creates a hash for a given secret */
   public function hash(string|Secret $secret): string {
-    return self::$hash->digest($password instanceof Secret ? $password->reveal() : $password)->hex();
+    return self::$hash->digest($secret instanceof Secret ? $secret->reveal() : $secret)->hex();
   }
 
   /** Authenticates a user, returning success or failure in a result object */

--- a/src/test/php/de/thekid/cas/unittest/SignedTest.php
+++ b/src/test/php/de/thekid/cas/unittest/SignedTest.php
@@ -17,19 +17,19 @@ class SignedTest {
     new Signed(new Secret(self::SECRET));
   }
 
-  #[Test, Values([0, 1, 6100, '62a6179f4c9ac9ab5cb437e3'])]
+  #[Test, Values([0, 1, 6100, '62a6179f4c9ac9ab5cb437e3', '4cf960df-2019-4963-9668-f17b3d08115c'])]
   public function roundtrip($value) {
     $fixture= new Signed(self::SECRET);
     Assert::equals((string)$value, $fixture->verify($fixture->id($value)));
   }
 
-  #[Test, Values([0, 1, 6100, '62a6179f4c9ac9ab5cb437e3'])]
+  #[Test, Values([0, 1, 6100, '62a6179f4c9ac9ab5cb437e3', '4cf960df-2019-4963-9668-f17b3d08115c'])]
   public function roundtrip_with_prefix($value) {
     $fixture= new Signed(self::SECRET);
     Assert::equals((string)$value, $fixture->verify($fixture->id($value, 'ST-'), 'ST-'));
   }
 
-  #[Test, Values(['0-', '1-ABC', '6100-3c3b7591af75211812281d52-missing'])]
+  #[Test, Values(['-', '-0', 'ABC-1', '3c3b7591af75211812281d52-6100'])]
   public function incorrect_hash($value) {
     $fixture= new Signed(self::SECRET);
     Assert::null($fixture->verify($value));

--- a/src/test/php/de/thekid/cas/unittest/SignedTest.php
+++ b/src/test/php/de/thekid/cas/unittest/SignedTest.php
@@ -17,16 +17,16 @@ class SignedTest {
     new Signed(new Secret(self::SECRET));
   }
 
-  #[Test, Values([0, 1, 6100])]
+  #[Test, Values([0, 1, 6100, '62a6179f4c9ac9ab5cb437e3'])]
   public function roundtrip($value) {
     $fixture= new Signed(self::SECRET);
-    Assert::equals($value, $fixture->verify($fixture->id($value)));
+    Assert::equals((string)$value, $fixture->verify($fixture->id($value)));
   }
 
-  #[Test, Values([0, 1, 6100])]
+  #[Test, Values([0, 1, 6100, '62a6179f4c9ac9ab5cb437e3'])]
   public function roundtrip_with_prefix($value) {
     $fixture= new Signed(self::SECRET);
-    Assert::equals($value, $fixture->verify($fixture->id($value, 'ST-'), 'ST-'));
+    Assert::equals((string)$value, $fixture->verify($fixture->id($value, 'ST-'), 'ST-'));
   }
 
   #[Test, Values(['0-', '1-ABC', '6100-3c3b7591af75211812281d52-missing'])]

--- a/src/test/php/de/thekid/cas/unittest/TestingTickets.php
+++ b/src/test/php/de/thekid/cas/unittest/TestingTickets.php
@@ -3,10 +3,8 @@
 use de\thekid\cas\tickets\Tickets;
 use unittest\Assert;
 
-class TestingTickets implements Tickets {
+class TestingTickets extends Tickets {
   private $backing= [];
-
-  public fn prefix() => 'ST-';
 
   public function create($value) {
     $this->backing[]= $value;

--- a/src/test/php/de/thekid/cas/unittest/TestingUsers.php
+++ b/src/test/php/de/thekid/cas/unittest/TestingUsers.php
@@ -1,30 +1,16 @@
 <?php namespace de\thekid\cas\unittest;
 
-use de\thekid\cas\users\{Authenticated, Authentication, NoSuchUser, PasswordMismatch, User, Users};
+use de\thekid\cas\users\{User, Users};
 use lang\MethodNotImplementedException;
-use unittest\Assert;
 use util\Secret;
 
-class TestingUsers implements Users {
+class TestingUsers extends Users {
   private $backing= [];
 
   public function __construct(array $users= []) {
     foreach ($users as $username => $password) {
-      $this->backing[$username]= $password instanceof Secret ? $password : new Secret($password);
+      $this->backing[$username]= $this->hash($password);
     }
-  }
-
-  /** Authenticates a user, returning success or failure in a result object */
-  public function authenticate(string $username, Secret $password): Authentication {
-    if (!isset($this->backing[$username])) {
-      return new NoSuchUser($username);
-    }
-
-    if (!$password->equals($this->backing[$username])) {
-      return new PasswordMismatch($username);
-    }
-
-    return new Authenticated(new User($username, []));
   }
 
   /** Returns all users */
@@ -34,13 +20,14 @@ class TestingUsers implements Users {
 
   /** Returns a user by a given username */
   public function named(string $username): ?User {
-    return isset($this->backing[$username]) ? new User($username, []) : null;
+    $hash= $this->backing[$username] ?? null;
+    return $hash ? new User($username, $hash, []) : null;
   }
 
   /** Creates a new user with a given username and password. */
   public function create(string $username, string|Secret $password): User {
-    $this->backing[$username]= $password instanceof Secret ? $password : new Secret($password);
-    return new User($username, []);
+    $this->backing[$username]= $this->hash($password);
+    return new User($username, $this->backing[$username], []);
   }
 
   /** Removes an existing user */
@@ -52,6 +39,6 @@ class TestingUsers implements Users {
   /** Changes a user's password. */
   public function password(string|User $user, string|Secret $password): void {
     $username= $user instanceof User ? $user->username() : $user;
-    $this->backing[$username]= $password instanceof Secret ? $password : new Secret($password);
+    $this->backing[$username]= $this->hash($password);
   }
 }


### PR DESCRIPTION
This pull request refactors persistence into something which can easily be extended, e.g. to allow for a MongoDB-based persistence.

## In a nutshell

* [x] Create a persistence interface and a database-driven implementation
* [x] Move tickets and users persistence implementations to dedicated package
* [x] Require persistence interface binding in configuration file
* [x] Normalize Users::all() to return User instances
* [x] Allow string IDs for tickets

## Code size

831 -> 869 lines, still under 1000 as advertised 🙃