### PR TITLE
Use AES instead of DES

### DIFF
--- a/src/main/php/de/thekid/cas/Encryption.php
+++ b/src/main/php/de/thekid/cas/Encryption.php
@@ -32,10 +32,10 @@ class Encryption {
         return $r;
       };
     } else if (extension_loaded('openssl')) {
-      self::$nlength= self::$klength= openssl_cipher_iv_length('DES');
-      self::$encrypt= fn($value, $nonce, $key) => openssl_encrypt($value, 'DES', $key->reveal(), 0, $nonce);
+      self::$nlength= self::$klength= openssl_cipher_iv_length('AES-128-CBC');
+      self::$encrypt= fn($value, $nonce, $key) => openssl_encrypt($value, 'AES-128-CBC', $key->reveal(), 0, $nonce);
       self::$decrypt= fn($cipher, $nonce, $key) => {
-        if (false === ($r= openssl_decrypt($cipher, 'DES', $key->reveal(), 0, $nonce))) {
+        if (false === ($r= openssl_decrypt($cipher, 'AES-128-CBC', $key->reveal(), 0, $nonce))) {
           $errors= [];
           while ($error= openssl_error_string()) {
             $errors[]= $error;


### PR DESCRIPTION
Prevents "[error:0308010C:digital envelope routines::unsupported]" errors in PHP 8.2, see [here](https://github.com/thekid/cas/runs/6849633483?check_suite_focus=true#step:10:11).

See also:

* xp-framework/core#309
* https://stackoverflow.com/questions/69692842/error-message-error0308010cdigital-envelope-routinesunsupported - same problem with newer Node versions
* https://github.com/openssl/openssl/blob/master/doc/man7/OSSL_PROVIDER-legacy.pod - "DES" algorithm considered legacy