### PR TITLE
Migrate to new testing library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,4 +56,4 @@ jobs:
         echo "vendor/autoload.php" > composer.pth
 
     - name: Run test suite
-      run: sh xp-run xp.unittest.TestRunner src/test/php
+      run: sh xp-run xp.test.Runner src/test/php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: PHP ${{ matrix.php-versions }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.php-versions == '8.2' }}
+    continue-on-error: ${{ matrix.php-versions == '8.3' }}
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
         os: [ubuntu-latest, windows-latest]
 
     steps:
@@ -24,7 +24,7 @@ jobs:
       run: git config --system core.autocrlf false; git config --system core.eol lf
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up PHP ${{ matrix.php-versions }}
       uses: shivammathur/setup-php@v2
@@ -43,7 +43,7 @@ jobs:
       run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
     - name: Cache dependencies
-      uses: actions/cache@v2.1.3
+      uses: actions/cache@v3
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev": {
-    "xp-framework/test": "dev-main"
+    "xp-framework/test": "^1.0"
   },
   "scripts": {
     "serve": "xp -supervise web -s de.thekid.cas.App"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php" : ">=7.0.0"
   },
   "require-dev": {
-    "xp-framework/unittest": "^11.0"
+    "xp-framework/test": "dev-main"
   },
   "scripts": {
     "serve": "xp -supervise web -s de.thekid.cas.App"

--- a/src/test/php/de/thekid/cas/unittest/EncryptionTest.php
+++ b/src/test/php/de/thekid/cas/unittest/EncryptionTest.php
@@ -2,7 +2,7 @@
 
 use de\thekid\cas\Encryption;
 use lang\FormatException;
-use unittest\{Assert, Test, Expect, Values};
+use test\{Assert, Before, Expect, Test, Values};
 use util\{Random, Secret};
 
 class EncryptionTest {

--- a/src/test/php/de/thekid/cas/unittest/HandlerTest.php
+++ b/src/test/php/de/thekid/cas/unittest/HandlerTest.php
@@ -1,6 +1,6 @@
 <?php namespace de\thekid\cas\unittest;
 
-use unittest\Assert;
+use test\{Assert, Before};
 use web\io\{TestInput, TestOutput};
 use web\session\ForTesting;
 use web\{Request, Response};

--- a/src/test/php/de/thekid/cas/unittest/LoginTest.php
+++ b/src/test/php/de/thekid/cas/unittest/LoginTest.php
@@ -1,13 +1,13 @@
 <?php namespace de\thekid\cas\unittest;
 
-use com\google\authenticator\{TimeBased, SecretBytes};
-use de\thekid\cas\flow\{DisplaySuccess, EnterCredentials, Flow, RedirectToService, UseService, QueryMFACode};
+use com\google\authenticator\{SecretBytes, TimeBased};
+use de\thekid\cas\flow\{DisplaySuccess, EnterCredentials, Flow, QueryMFACode, RedirectToService, UseService};
 use de\thekid\cas\impl\Login;
 use de\thekid\cas\services\Services;
 use de\thekid\cas\tickets\Tickets;
 use de\thekid\cas\users\{NoSuchUser, PasswordMismatch};
-use de\thekid\cas\{Signed, Encryption};
-use unittest\{Assert, Test};
+use de\thekid\cas\{Encryption, Signed};
+use test\{Assert, Before, Test, Values};
 use util\Random;
 
 class LoginTest extends HandlerTest {

--- a/src/test/php/de/thekid/cas/unittest/LogoutTest.php
+++ b/src/test/php/de/thekid/cas/unittest/LogoutTest.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\cas\unittest;
 
 use de\thekid\cas\impl\Logout;
-use unittest\{Assert, Test};
+use test\{Assert, Test};
 
 class LogoutTest extends HandlerTest {
   private $templates;

--- a/src/test/php/de/thekid/cas/unittest/SignedTest.php
+++ b/src/test/php/de/thekid/cas/unittest/SignedTest.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\cas\unittest;
 
 use de\thekid\cas\Signed;
-use unittest\{Assert, Test, Values};
+use test\{Assert, Test, Values};
 use util\Secret;
 
 class SignedTest {

--- a/src/test/php/de/thekid/cas/unittest/TemplateEngineTest.php
+++ b/src/test/php/de/thekid/cas/unittest/TemplateEngineTest.php
@@ -3,7 +3,7 @@
 use com\github\mustache\{InMemory, TemplateNotFoundException};
 use de\thekid\cas\TemplateEngine;
 use io\Path;
-use unittest\{Assert, Test};
+use test\{Assert, Expect, Test};
 use web\Response;
 use web\io\{Buffered, TestOutput};
 

--- a/src/test/php/de/thekid/cas/unittest/TestingTemplates.php
+++ b/src/test/php/de/thekid/cas/unittest/TestingTemplates.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\cas\unittest;
 
 use de\thekid\cas\Templating;
-use unittest\Assert;
+use test\Assert;
 
 class TestingTemplates implements Templating {
   private $rendered= [];

--- a/src/test/php/de/thekid/cas/unittest/TestingTickets.php
+++ b/src/test/php/de/thekid/cas/unittest/TestingTickets.php
@@ -1,7 +1,7 @@
 <?php namespace de\thekid\cas\unittest;
 
 use de\thekid\cas\tickets\Tickets;
-use unittest\Assert;
+use test\Assert;
 
 class TestingTickets extends Tickets {
   private $backing= [];

--- a/src/test/php/de/thekid/cas/unittest/ValidateTest.php
+++ b/src/test/php/de/thekid/cas/unittest/ValidateTest.php
@@ -2,7 +2,7 @@
 
 use de\thekid\cas\Signed;
 use de\thekid\cas\impl\Validate;
-use unittest\{Assert, Test};
+use test\{Assert, Before, Test};
 use web\io\{TestInput, TestOutput};
 use web\{Request, Response};
 


### PR DESCRIPTION
See https://github.com/xp-framework/rfc/issues/344 and https://github.com/xp-framework/test. Mostly migrated automatically, needed to add missing annotation imports in various places.

## Timing

Before
```
Tests:       61 passed
Memory used: 5722.86 kB (5775.77 kB peak)
Time taken:  0.147 seconds
```

After
```
Test cases:  61 succeeded
Memory used: 5591.96 kB (5646.14 kB peak)
Time taken:  0.163 seconds (0.555 seconds overall)
```